### PR TITLE
Fixed CopperBar Rightclick Text

### DIFF
--- a/SQF/dayz_code/Configs/CfgMagazines/DZE/Currency/CopperBar.hpp
+++ b/SQF/dayz_code/Configs/CfgMagazines/DZE/Currency/CopperBar.hpp
@@ -8,7 +8,7 @@ class ItemCopperBar: CA_Magazine {
 	descriptionShort = $STR_EPOCH_COPPER_DESC;
 	class ItemActions {
 		class Crafting {
-			text = $STR_EPOCH_PLAYER_210;
+			text = $STR_EPOCH_PLAYER_210_9;
 			script = ";['Crafting','CfgMagazines', _id] spawn player_craftItem;";
 			neednearby[] = {};
 			requiretools[] = {};


### PR DESCRIPTION
The rightclick  text to craft  1x 10oz copper bar, when you need 9 more copper bars, was not visible.